### PR TITLE
Update bindings for ctypes-0.6 compatibility.

### DIFF
--- a/lib_gen/LZ4_bindings.ml
+++ b/lib_gen/LZ4_bindings.ml
@@ -1,13 +1,13 @@
 open Ctypes
 
 module C(F: Cstubs.FOREIGN) = struct
-  let compressBound = F.foreign "LZ4_compressBound" (int @-> returning int)
-  let b_compress    = F.foreign "LZ4_compress_limitedOutput"
-                                (ocaml_bytes @-> ocaml_bytes @-> int @-> int @-> returning int)
-  let ba_compress   = F.foreign "LZ4_compress_limitedOutput"
-                                (ptr char @-> ptr char @-> int @-> int @-> returning int)
-  let b_decompress  = F.foreign "LZ4_decompress_safe"
-                                (ocaml_bytes @-> ocaml_bytes @-> int @-> int @-> returning int)
-  let ba_decompress = F.foreign "LZ4_decompress_safe"
-                                (ptr char @-> ptr char @-> int @-> int @-> returning int)
+  let compressBound = F.(foreign "LZ4_compressBound" (int @-> returning int))
+  let b_compress    = F.(foreign "LZ4_compress_limitedOutput"
+                                (ocaml_bytes @-> ocaml_bytes @-> int @-> int @-> returning int))
+  let ba_compress   = F.(foreign "LZ4_compress_limitedOutput"
+                                (ptr char @-> ptr char @-> int @-> int @-> returning int))
+  let b_decompress  = F.(foreign "LZ4_decompress_safe"
+                                (ocaml_bytes @-> ocaml_bytes @-> int @-> int @-> returning int))
+  let ba_decompress = F.(foreign "LZ4_decompress_safe"
+                                (ptr char @-> ptr char @-> int @-> int @-> returning int))
 end


### PR DESCRIPTION
The next release of ctypes will include a small backwards-incompatible change to the `Cstubs` interface: `@->` and `returning` used in a bindings functor should now be imported from the functor argument, not from `Ctypes`.

See the following PR for more details: https://github.com/ocamllabs/ocaml-ctypes/pull/389

This pull request changes the `LZ4_bindings` module to be compatible both with existing versions of ctypes and with the forthcoming 0.6 release.