### PR TITLE
Fix linking when using lz4 with OCaml < 4.08

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name lz4)
  (wrapped false)
- (libraries ctypes lz4.generated lz4.bindings)
+ (libraries ctypes lz4.generated lz4.bindings bigarray)
  (public_name lz4))


### PR DESCRIPTION
As shown by the tests on OCaml 4.07:
```
#=== ERROR while compiling lz4.1.2.0 ==========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.07.1 | pinned(https://github.com/whitequark/ocaml-lz4/archive/v1.2.0.tar.gz)
# path                 ~/.opam/4.07/.opam-switch/build/lz4.1.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -j 31 -p lz4
# exit-code            1
# env-file             ~/.opam/log/lz4-265-e4aeac.env
# output-file          ~/.opam/log/lz4-265-e4aeac.out
### output ###
# (cd _build/default && /home/opam/.opam/4.07/bin/ocamlopt.opt -w -40 -strict-sequence -safe-string -warn-error -a+8 -g -o lib_test/test_LZ4.exe /home/opam/.opam/4.07/lib/bigarray-compat/bigarray_compat.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/4.07/lib/integers/integers.cmxa -I /home/opam/.opam/4.07/lib/integers /home/opam/.opam/4.07/lib/ctypes/ctypes.cmxa -I /home/opam/.opam/4.07/lib/ctypes lib_gen/lz4_generated.cmxa -I lib_gen lib_gen/lz4_bindings.cmxa lib/lz4.cmxa /home/opam/.opam/4.07/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/ounit2/advanced/oUnitAdvanced.cmxa /home/opam/.opam/4.07/lib/ounit2/oUnit.cmxa lib_test/.test_LZ4.eobjs/native/dune__exe__Test_LZ4.cmx)
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Bigarray referenced from lib/lz4.cmxa(LZ4),
#            lib_test/.test_LZ4.eobjs/native/dune__exe__Test_LZ4.cmx
```