### PR TITLE
add missing ctypes.stubs lib dep

### DIFF
--- a/lib_gen/dune
+++ b/lib_gen/dune
@@ -3,7 +3,7 @@
  (public_name lz4.bindings)
  (wrapped false)
  (modules LZ4_bindings)
- (libraries ctypes))
+ (libraries ctypes ctypes.stubs))
 
 (library
  (name lz4_generated)


### PR DESCRIPTION
Explicitly declare dependency on `ctypes.stubs` for the lz4.bindings lib.

I guess this is usually picked up when building the executable as the dependency is added there, but in some situtations dune seems to need this on the lib itself too.