### PR TITLE
Use pkg-config via dune-configurator to find lz4

### DIFF
--- a/lib_gen/config/discover.ml
+++ b/lib_gen/config/discover.ml
@@ -1,0 +1,11 @@
+let () =
+  let module C = Configurator.V1 in
+  let open C.Pkg_config in
+  let run_opt default = function | None -> default | Some x -> x in
+  let bind_opt m f = match m with | None -> None | Some x -> f x in (* monad *)
+  C.main ~name:"lz4" (fun c ->
+    let conf = run_opt {libs = ["-llz4"]; cflags = []} (* fallback => hope for the best *)
+                       (bind_opt (C.Pkg_config.get c) (C.Pkg_config.query ~package:"liblz4"))
+    in
+    C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+    C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/lib_gen/config/dune
+++ b/lib_gen/config/dune
@@ -1,0 +1,3 @@
+(executable
+  (name discover)
+  (libraries dune.configurator))

--- a/lib_gen/dune
+++ b/lib_gen/dune
@@ -12,14 +12,20 @@
  (modules LZ4_generated)
  (foreign_stubs
   (language c)
+  (flags :standard (:include c_flags.sexp))
   (names LZ4_stubs))
- (c_library_flags -llz4)
+ (c_library_flags (:include c_library_flags.sexp))
  (libraries ctypes))
 
 (executable
  (name LZ4_bindgen)
  (modules LZ4_bindgen)
  (libraries ctypes.stubs lz4.bindings))
+
+(rule
+  (targets c_flags.sexp c_library_flags.sexp)
+  (deps (:discover config/discover.exe))
+  (action (run %{discover})))
 
 (rule
  (targets LZ4_generated.ml LZ4_stubs.c)

--- a/lz4.opam
+++ b/lz4.opam
@@ -19,6 +19,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "conf-liblz4"
   "dune" { >= "2.0" }
+  "dune-configurator"
   "ctypes" {>= "0.4.1"}
   "ounit2" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
This PR modifies the build process to use pkg-config to find the lz4 include and library paths, via the dune-configurator mechanism. The problem was discovered when trying to build lz4 on a Mac with the base lz4 provided by Macports as opposed to homebrew.
Please forgive any formatting blunders in my OCaml code - this is the first time I've contributed to a shared OCaml repository and left to itself my formatting tends towards the compact! Do let me know if I should format it differently.